### PR TITLE
Fix 7.2

### DIFF
--- a/Code/Triggers.lua
+++ b/Code/Triggers.lua
@@ -706,7 +706,7 @@ local function getIconPath(icon)
 
 	local path = iconCache[icon]
 	if not path then
-		local texture = GetSpellTextureFileName(icon)
+		local texture = GetSpellTexture(icon)
 		if texture then
 			path = texture
 		else

--- a/Data/Auras.lua
+++ b/Data/Auras.lua
@@ -20,7 +20,7 @@ local PET_FLAGS = bit.bor(
 )
 
 local function getIcon(info)
-	return GetSpellTextureFileName(info.spellID)
+	return GetSpellTexture(GetSpellInfo(info.spellID))
 end
 
 local function retrieveDestName(info)

--- a/Data/CombatEvents.lua
+++ b/Data/CombatEvents.lua
@@ -173,18 +173,18 @@ end
 -- people.
 --]]
 local dumbTriggerSpellOverride = {
-	[22482] = GetSpellTextureFileName(13877), -- Blade Flurry
-	[5374] = GetSpellTextureFileName(1329), -- Mutilate
-	[27576] = GetSpellTextureFileName(1329), -- Mutilate Off-Hand
-	[222031] = GetSpellTextureFileName(162794), -- Chaos Strike
-	[199547] = GetSpellTextureFileName(162794), -- Chaos Strike
+	[22482] = GetSpellTexture(GetSpellInfo(13877)), -- Blade Flurry
+	[5374] = GetSpellTexture(GetSpellInfo(1329)), -- Mutilate
+	[27576] = GetSpellTexture(GetSpellInfo(1329)), -- Mutilate Off-Hand
+	[222031] = GetSpellTexture(GetSpellInfo(162794)), -- Chaos Strike
+	[199547] = GetSpellTexture(GetSpellInfo(162794)), -- Chaos Strike
 }
 
 --[[
 -- helperfunction to retrieve an icon
 --]]
 local function retrieveIconFromAbilityName(info)
-	return dumbTriggerSpellOverride[info.spellID] or GetSpellTextureFileName(info.spellID or info.abilityName)
+	return dumbTriggerSpellOverride[info.spellID] or GetSpellTexture(GetSpellInfo(info.spellID) or info.abilityName)
 end
 
 --[[

--- a/Data/Cooldowns.lua
+++ b/Data/Cooldowns.lua
@@ -136,7 +136,7 @@ function module:CheckSpells(e)
 			for spellName in next, expired do
 				local group = spellGroups[spellName]
 				if not group then -- normal cooldown finish
-					local texture = GetSpellTextureFileName(spellName)
+					local texture = GetSpellTexture(spellName)
 					local info = newList(spellName, texture)
 					Parrot:TriggerCombatEvent("Notification", "Skill cooldown finish", info)
 					info = del(info)
@@ -286,4 +286,3 @@ function module:OnOptionsCreate()
 
 	Parrot:AddOption("cooldowns", options)
 end
-

--- a/Parrot.toc
+++ b/Parrot.toc
@@ -1,4 +1,4 @@
-## Interface: 70100
+## Interface: 70200
 ## Title: Parrot 2
 ## Notes: Floating Combat Text of awesomeness. Caw. It'll eat your crackers.
 ## Notes-deDE: Scrollender Kampftext der Ungeheuerlichkeit. Kraaaah!


### PR DESCRIPTION
As discussed in #18, calls for `GetSpellTextureFileName` got replaced with `GetSpellTexture`. Hope I did not miss something.