### PR TITLE
Apply filter to the post-throttle amount

### DIFF
--- a/Code/CombatEvents.lua
+++ b/Code/CombatEvents.lua
@@ -1888,22 +1888,6 @@ function module:TriggerCombatEvent(category, name, info, throttleDone)
 		return
 	end
 
-	local filterType = data.filterType
-	if filterType then
-		local actualType = filterType[1]
-		local filterKey = filterType[2]
-		local base = db.filters[actualType] or filterDefaults[actualType]
-		local info_filterKey
-		if type(filterKey) == "function" then
-			info_filterKey = filterKey(info)
-		else
-			info_filterKey = info[filterKey]
-		end
-		if info_filterKey < base then
-			return
-		end
-	end
-
 	if throttleDone then
 		if info[STHROTTLE] then
 			if info[STHROTTLE].waitStyle then
@@ -2020,6 +2004,22 @@ Parrot.TriggerCombatEvent = module.TriggerCombatEvent
 local function runEvent(category, name, info)
 	local cdb = db[category][name]
 	local data = combatEvents[category][name]
+
+	local filterType = data.filterType
+	if filterType then
+		local actualType = filterType[1]
+		local filterKey = filterType[2]
+		local base = db.filters[actualType] or filterDefaults[actualType]
+		local info_filterKey
+		if type(filterKey) == "function" then
+			info_filterKey = filterKey(info)
+		else
+			info_filterKey = info[filterKey]
+		end
+		if info_filterKey < base then
+			return
+		end
+	end
 
 	local throttle = data.throttle
 	local throttleSuffix


### PR DESCRIPTION
Currently, filters are applied to raw events, before they are aggregated by throttles. I think this behavior is undesirable, and instead filters should be applied to the post-throttle amount. Basically, I think filters should be *display* filters and not *event* filters.

If I set outgoing damage filter to 100k it means I generally don't want to see my damaging abilities below 100k. However, if I set a long throttle window, it means I *do* want to see e.g. accumulated dot ticks if the total amount is substantial. As an extreme example if my throttle window is 3 seconds, and my dot ticks 75k every 0.5 seconds, then in the status quo, the accumulated 450k would not be shown because each tick has been filtered. My patch makes makes it so that the filter is applied *after* the throttle, so 450k > 100k and it would be shown.