### PR TITLE
Sanitize power gain amounts

### DIFF
--- a/Data/CombatEvents.lua
+++ b/Data/CombatEvents.lua
@@ -110,6 +110,10 @@ local damageTypeString = function(info)
 	end
 end
 
+local sanitizedPowerAmount = function(info)
+	return math.floor(10 * info.amount + 0.5) / 10
+end
+
 local classColorStrings = {}
 for k, v in next, _G.RAID_CLASS_COLORS do
 	classColorStrings[k] = ("|c%s%%s|r"):format(v.colorStr)
@@ -1843,7 +1847,7 @@ Parrot:RegisterCombatEvent{
 		SPELL_PERIODIC_LEECH = { check = checkPlayerOut, },
 	},
 	tagTranslations = {
-		Amount = "amount",
+		Amount = sanitizedPowerAmount,
 		Type = powerTypeString,
 		Skill = retrieveAbilityName,
 		Name = function(info)


### PR DESCRIPTION
This fixes the issue of Parrot displaying absurd numbers for power gains in certain situations. When the left-most Shadow Priest talent is chosen, the combat log can provide weird numbers for the Insanity gains. Mind Blast, which normally grants 12 Insanity, now provides 20% additional Insanity, resulting in the combat log parser getting "14.3999999something", which is not what we want to be displaying. This fix would round such fractional resource gains to one digit behind the decimal point at a maximum. It will still display integer resource gains normally, but would display the above as "14.4" instead, for example

This issue occurs with other SCT addons, too, by the way, so maybe the real fix should be on Blizzard's end, but this seems like an okay bandaid to me