### PR TITLE
Fix loot total bug

### DIFF
--- a/Data/Loot.lua
+++ b/Data/Loot.lua
@@ -56,7 +56,7 @@ local function parse_CHAT_MSG_LOOT(chatmsg)
 		return newDict(
 			"name", name,
 			"amount", amount,
-			"total", GetItemCount(itemLink) + amount,
+			"total", GetItemCount(itemLink),
 			"icon", texture
 		)
 	end


### PR DESCRIPTION
`GetItemCount` already gets the total number.