### PR TITLE
Added options to show loot based on item quality and always show quest items

### DIFF
--- a/Code/CombatEvents.lua
+++ b/Code/CombatEvents.lua
@@ -385,6 +385,12 @@ function module:OnOptionsCreate()
 		db[category][arg][name] = value
 	end
 
+	local qualityPoor = select(4, GetItemQualityColor(0))
+	local qualityCommon = select(4, GetItemQualityColor(1))
+	local qualityUncommon = select(4, GetItemQualityColor(2))
+	local qualityRare = select(4, GetItemQualityColor(3))
+	local qualityEpic = select(4, GetItemQualityColor(4))
+
 	local events_opt
 	events_opt = {
 		type = 'group',
@@ -418,6 +424,66 @@ function module:OnOptionsCreate()
 							checkZone()
 						end,
 						order = 2,
+					},
+				},
+			},
+			lootoptions = {
+				name = "Loot options",
+				type = 'group',
+				inline = true,
+				args = {
+					lootQuestItem = {
+						type = 'toggle',
+						name = L["Always show quest items"],
+						set = function(info, value)
+							setOption(info, value)
+						end,
+						order = 1,
+					},
+					sep = {
+						type = "description",
+						name = "",
+						order = 2,
+					},
+					lootQualityPoor = {
+						type = 'toggle',
+						name = "|c"..qualityPoor..L["Poor"].."|r",
+						set = function(info, value)
+							setOption(info, value)
+						end,
+						order = 3,
+					},
+					lootQualityCommon = {
+						type = 'toggle',
+						name = "|c"..qualityCommon..L["Common"].."|r",
+						set = function(info, value)
+							setOption(info, value)
+						end,
+						order = 4,
+					},
+					lootQualityUncommon = {
+						type = 'toggle',
+						name = "|c"..qualityUncommon..L["Uncommon"].."|r",
+						set = function(info, value)
+							setOption(info, value)
+						end,
+						order = 5,
+					},
+					lootQualityRare = {
+						type = 'toggle',
+						name = "|c"..qualityRare..L["Rare"].."|r",
+						set = function(info, value)
+							setOption(info, value)
+						end,
+						order = 6,
+					},
+					lootQualityEpic = {
+						type = 'toggle',
+						name = "|c"..qualityEpic..L["Epic"].."|r",
+						set = function(info, value)
+							setOption(info, value)
+						end,
+						order = 7,
 					},
 				},
 			},

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -1,7 +1,7 @@
 local debug = true
---@debug@
+--[==[@debug@
 debug = nil
---@end-debug@
+--@end-debug@]==]
 
 local L = LibStub("AceLocale-3.0"):NewLocale("Parrot", "enUS", true, debug)
 
@@ -600,3 +600,10 @@ L["[Text] (crit)"] = true
 L["[Text] (crushing)"] = true
 L["[Text] (glancing)"] = true
 L["[[Spell] ready!]"] = true
+L["Loot options"] = true
+L["Always show quest items"] = true
+L["Poor"] = true
+L["Common"] = true
+L["Uncommon"] = true
+L["Rare"] = true
+L["Epic"] = true


### PR DESCRIPTION
Added options to show loot based on item quality of the item looted, as well as an option to always show quest items looted.

Localization is only done for enUS, these keys are added.

```
L["Loot options"] = true
L["Always show quest items"] = true
L["Poor"] = true
L["Common"] = true
L["Uncommon"] = true
L["Rare"] = true
L["Epic"] = true
```

Not sure if the item quality names are localized in the WoW API, if so those should be used instead.

This partially fixes #63, I was using MSBT as well and I really liked this feature in it. I usually don't care about poor and common items but it's very nice too see when you get a good drop.

I'm unable to upload a screenshot to github, so here's an externally hosted:
[https://i.imgur.com/Pd0GGs4.png](https://i.imgur.com/Pd0GGs4.png)