### PR TITLE
Fix error when using a rune on a weapon, or adding an enchant to an item

### DIFF
--- a/Data/Auras.lua
+++ b/Data/Auras.lua
@@ -510,7 +510,7 @@ Parrot:RegisterCombatEvent{
 		Name = "abilityName",
 		ItemName = "itemName",
 		Icon = function(info)
-			return GetItemIcon(info.itemId)
+			return GetItemIcon(info.itemID)
 		end,
 	},
 	tagTranslationsHelp = {
@@ -538,7 +538,7 @@ Parrot:RegisterCombatEvent{
 		Name = "abilityName",
 		ItemName = "itemName",
 		Icon = function(info)
-			return GetItemIcon(info.itemId)
+			return GetItemIcon(info.itemID)
 		end,
 	},
 	tagTranslationsHelp = {


### PR DESCRIPTION
I don't know what changed as I'm not familiar with addon development or Lua, but in the `info` table, there is a `itemID` value while there isn't a `itemId` one, so this fix got rid of the error and I properly see the event from Parrot on my screen