### PR TITLE
fix missing spells in cooldown feature

### DIFF
--- a/Data/Cooldowns.lua
+++ b/Data/Cooldowns.lua
@@ -82,7 +82,7 @@ function module:ResetSpells(e)
 	wipe(spells)
 	wipe(spellCooldowns)
 	-- cache spells from our current spec plus racials
-	for tab = 1, 2 do
+	for tab = 1, GetNumSpellTabs() do
 		local _, _, offset, numSlots = GetSpellTabInfo(tab)
 		for slot = 1, numSlots do
 			local index = offset + slot


### PR DESCRIPTION
it used to query only first and second spellbook tabs. fix this to fully read a player's spellbook and add spells cooldown data. reference: https://wowpedia.fandom.com/wiki/API_GetSpellTabInfo